### PR TITLE
fix: restore visual usage color tiers in Waybar

### DIFF
--- a/code_usage/formatting.py
+++ b/code_usage/formatting.py
@@ -32,6 +32,19 @@ def status_from_utilization(utilization: float) -> str:
     return "ok"
 
 
+def usage_tier_class(utilization: float) -> str:
+    """Map utilization to a granular Waybar CSS class."""
+    if utilization >= 95:
+        return "usage-95"
+    if utilization >= 85:
+        return "usage-85"
+    if utilization >= 70:
+        return "usage-70"
+    if utilization >= 50:
+        return "usage-50"
+    return "usage-0"
+
+
 def color_for_utilization(utilization: float) -> str:
     """Get ANSI color code for utilization."""
     if utilization >= 90:
@@ -196,6 +209,7 @@ def build_waybar_payload(
     active = any(count > 0 for count in program_counts.values())
     percentage = int(primary.max_utilization)
     status = status_from_utilization(primary.max_utilization)
+    tier_class = usage_tier_class(primary.max_utilization)
 
     text = f"\uf121 {percentage}%"
     if not active:
@@ -232,7 +246,7 @@ def build_waybar_payload(
     return {
         "text": text,
         "tooltip": "\n".join(tooltip_lines),
-        "class": status,
+        "class": [status, tier_class, "active" if active else "idle"],
         "percentage": percentage,
         "alt": primary.key if active else "idle",
     }

--- a/waybar/OMARCHY.md
+++ b/waybar/OMARCHY.md
@@ -98,17 +98,29 @@ Do not edit files under `~/.local/share/omarchy/`.
   margin: 0 8px;
 }
 
-#custom-code-usage.ok {
+#custom-code-usage.usage-0 {
   color: #a6e3a1;
 }
 
-#custom-code-usage.warning {
+#custom-code-usage.usage-50 {
+  color: #94e2d5;
+}
+
+#custom-code-usage.usage-70 {
   color: #f9e2af;
 }
 
-#custom-code-usage.critical,
+#custom-code-usage.usage-85 {
+  color: #fab387;
+}
+
+#custom-code-usage.usage-95,
 #custom-code-usage.error {
   color: #f38ba8;
+}
+
+#custom-code-usage.idle {
+  opacity: 0.65;
 }
 ```
 

--- a/waybar/README.md
+++ b/waybar/README.md
@@ -74,17 +74,29 @@ Add this to `~/.config/waybar/style.css`:
   margin: 0 8px;
 }
 
-#custom-code-usage.ok {
+#custom-code-usage.usage-0 {
   color: #a6e3a1;
 }
 
-#custom-code-usage.warning {
+#custom-code-usage.usage-50 {
+  color: #94e2d5;
+}
+
+#custom-code-usage.usage-70 {
   color: #f9e2af;
 }
 
-#custom-code-usage.critical,
+#custom-code-usage.usage-85 {
+  color: #fab387;
+}
+
+#custom-code-usage.usage-95,
 #custom-code-usage.error {
   color: #f38ba8;
+}
+
+#custom-code-usage.idle {
+  opacity: 0.65;
 }
 ```
 

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -4,15 +4,27 @@
     margin: 0 8px;
 }
 
-#custom-code-usage.ok {
+#custom-code-usage.usage-0 {
     color: #a6e3a1;
 }
 
-#custom-code-usage.warning {
+#custom-code-usage.usage-50 {
+    color: #94e2d5;
+}
+
+#custom-code-usage.usage-70 {
     color: #f9e2af;
 }
 
-#custom-code-usage.critical,
+#custom-code-usage.usage-85 {
+    color: #fab387;
+}
+
+#custom-code-usage.usage-95,
 #custom-code-usage.error {
     color: #f38ba8;
+}
+
+#custom-code-usage.idle {
+    opacity: 0.65;
 }


### PR DESCRIPTION
## Summary
Restores clearer, more visual percentage signaling in Waybar after the CSS simplification.

## Changes
- Added granular usage tier classes in Waybar payload generation:
  - `usage-0`, `usage-50`, `usage-70`, `usage-85`, `usage-95`
- Kept existing status classes while returning a class list (`status`, `tier`, `active|idle`).
- Updated `waybar/style.css` to map each usage tier to a distinct color and dim idle mode.
- Updated CSS snippets in `waybar/README.md` and `waybar/OMARCHY.md`.

## Validation
- `python3 -m py_compile code_usage/*.py code_usage/providers/*.py waybar/*.py`
- Manual payload check from installed helper:
  - `~/.local/bin/code-usage-waybar --provider auto`
  - Emits classes like `["warning", "usage-70", "active"]`

Closes #6
